### PR TITLE
Disable hash checking of new docs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,11 +69,12 @@ sources:
   # These orgs contain repositories with relevant BossDB tools and documentation
   github_orgs:
     - "jhuapl-boss"
-    - "aplbrain"
 
 index_settings:
-  force_reload: false  # Set to true to force rebuild (of only docs in config)
-  # Set to false to process all documents, only gets new vector embedding if doc changed.
-  # If true will not process existing documents, even if out of date as it will not even download them again.
+  # Set to true to force reprocess all docs for the vector DB
+  force_reload: false
+
+  # Set to false to process all documents.
+  # If true will not process existing documents, even if out of date as it will not download them again to check.
   # Does not remove docs if no longer in config, use force_reload to get a clean start.
   incremental: false

--- a/create_index.py
+++ b/create_index.py
@@ -1,3 +1,5 @@
+# SCRIPT is still a WORK-IN-PROGRESS and may not fully work yet
+
 import asyncio
 import logging
 import os

--- a/rag/index_builder.py
+++ b/rag/index_builder.py
@@ -105,7 +105,7 @@ class IndexBuilder:
         urls: List[str],
         orgs: List[str],
         github_token: Optional[str],
-        force_reload: bool = False,
+        check_hash: bool = False,
     ) -> List[Document]:
         """Process documents that haven't been indexed yet or need updating.
 
@@ -113,7 +113,7 @@ class IndexBuilder:
             urls (List[str]): List of URLs to process
             orgs (List[str]): List of GitHub organizations to process
             github_token (Optional[str]): GitHub access token
-            force_reload (bool): Whether to force reprocessing of all documents
+            check_hash (bool): Whether to check hash before adding as new document
 
         Returns:
             List[Document]: List of processed documents that need to be added/updated
@@ -131,7 +131,7 @@ class IndexBuilder:
             url = doc.metadata.get("url", "")
             org = doc.metadata.get("organization", "")
 
-            if force_reload or (
+            if not check_hash or (
                 doc_hash != self.metadata["document_hashes"].get(url, "")
             ):
                 processed_docs = self.splitter.split(doc)
@@ -242,7 +242,7 @@ class IndexBuilder:
                 new_urls,
                 new_orgs,
                 github_token,
-                force_reload,
+                check_hash=False,
             )
 
             if new_documents:


### PR DESCRIPTION
Close #8 by disabling hash. Alternative solution could be more url/org aware to overwrite old documents. For now, documents will just have to be fully processed when incremental is false, which results in additional processing of the embedding model.